### PR TITLE
Remove unused trompace config.secure flag

### DIFF
--- a/tpl/application.py
+++ b/tpl/application.py
@@ -42,7 +42,6 @@ class TPLapp():
         self.ce_config = ce_config
         self.application_config = application_config
         trompace.config.config.load(ce_config)
-       # self.secure = trompace.config.config.secure
 
         self.config_parser = configparser.ConfigParser()
         self.config_parser.read(application_config)

--- a/tpl/client.py
+++ b/tpl/client.py
@@ -14,7 +14,6 @@ class TPLclient():
         trompace.config.config.load(client_config)
         self.config_parser = configparser.ConfigParser()
         self.config_parser.read(client_config)
-    #    self.secure = trompace.config.config.secure
         self.authenticate = self.config_parser.getboolean('auth', 'required')
         self.inputs_n = int(self.config_parser['application']['inputs_n'])
         self.params_n = int(self.config_parser['application']['params_n'])


### PR DESCRIPTION
I removed the config.secure flag from the trompace client because it was causing some confusion and wasn't actually needed.
The TPL was reading this value in a few places, but wasn't actually using it, so remove them